### PR TITLE
fix(deploy.py): don't replace if string is None

### DIFF
--- a/rootfs/deploy.py
+++ b/rootfs/deploy.py
@@ -12,7 +12,9 @@ from urllib.parse import urlparse
 def log_output(stream, decode):
     for chunk in stream:
         if decode:
-            print(chunk.get('stream').replace('\n',''))
+            stream_chunk = chunk.get('stream')
+            if stream_chunk:
+                print(stream_chunk.replace('\n', ''))
         else:
             print(chunk.decode('utf-8'))
 


### PR DESCRIPTION
In testing Deis v2 with example-dockerfile-python, I see logging errors. This should fix the python `AttributeError`:

``` console
$ git push deis master
Counting objects: 47, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (45/45), done.
Writing objects: 100% (47/47), 7.06 KiB | 0 bytes/s, done.
Total 47 (delta 8), reused 0 (delta 0)
remote: 2016/02/18 20:11:08 Running in debug mode
Running git hook
read [0000000000000000000000000000000000000000,196eb7187d2362d92a28fd3deef691acd468dfc1,refs/heads/master]
Workflow request /v2/hooks/push (body elided)
Workflow request POST /v2/hooks/config
{"receive_user":"matt","receive_repo":"mystic-original"}
...
download tar file complete
extracting tar file complete
Step 0 : FROM gliderlabs/alpine:3.1
Traceback (most recent call last):
  File "/deploy.py", line 50, in <module>
    log_output(stream, True)
  File "/deploy.py", line 15, in log_output
    print(chunk.get('stream').replace('\n',''))
AttributeError: 'NoneType' object has no attribute 'replace'
remote: 2016/02/18 20:11:18 Error running git receive hook [Stopping build.]
size of streamed logs 351
To ssh://git@deis.192.168.64.2.xip.io:2222/mystic-original.git
 * [new branch]      master -> master
```
