### PR TITLE
fix(deploy.py): hide Docker output stream unless DEBUG is on

### DIFF
--- a/rootfs/deploy.py
+++ b/rootfs/deploy.py
@@ -13,6 +13,10 @@ from oauth2client.service_account import ServiceAccountCredentials
 from gcloud.storage.client import Client
 from azure.storage.blob import BlockBlobService
 
+
+DEBUG = os.environ.get('DEBUG') in ('true', '1')
+
+
 def log_output(stream, decode):
     for chunk in stream:
         if decode:
@@ -102,4 +106,5 @@ stream = client.build(tag=repo, stream=True, decode=True, rm=True, path='/app')
 log_output(stream, True)
 print("pushing to registry")
 stream = client.push(registry+'/'+imageName, tag=imageTag, stream=True, insecure_registry=True)
-log_output(stream, False)
+if DEBUG:
+    log_output(stream, False)


### PR DESCRIPTION
The `DEBUG` flag is successfully passed through from deis-builder, but dockerbuilder wasn't doing anything with it. This hides the `docker push` streaming output after a build from the client unless `DEBUG=true`. In particular, lines such as this are gone except with `DEBUG`:

```
{"status":"Pushing","progressDetail":{"current":491521,"total":2242091},"progress":"[==========\u003e                                        ] 491.5 kB/2.242 MB","id":"bdf8036b1c64"}
```

Now it looks like:

```
$ git push deis master
Counting objects: 47, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (37/37), done.
Writing objects: 100% (47/47), 7.09 KiB | 0 bytes/s, done.
Total 47 (delta 7), reused 0 (delta 0)
Starting build... but first, coffee!
download tar file complete
extracting tar file complete
Step 0 : FROM alpine:3.1
 ---> bdf8036b1c64
Step 1 : RUN apk add -U     bash    nginx   && rm -rf /var/cache/apk*
 ---> Using cache
 ---> 2e3314c8728d
Step 2 : RUN ln -sf /dev/stdout /var/log/nginx/access.log
 ---> Using cache
 ---> 147f5086d9d2
Step 3 : RUN ln -sf /dev/stderr /var/log/nginx/error.log
 ---> Using cache
 ---> 9bdd4aa64527
Step 4 : ENV POWERED_BY Deis
 ---> Using cache
 ---> 656ce6923d8c
Step 5 : COPY rootfs /
 ---> Using cache
 ---> 8a77d0b9aa42
Step 6 : CMD /bin/boot
 ---> Using cache
 ---> 10f273ff5245
Step 7 : EXPOSE 80
 ---> Using cache
 ---> cda567da526f
Successfully built cda567da526f
pushing to registry
Build complete.
Launching app.
Launching...
Done, hungry-gatepost:v2 deployed to Deis

Use 'deis open' to view this application in your browser

To learn more, use 'deis help' or visit http://deis.io

To ssh://git@deis.192.168.64.2.nip.io:2222/hungry-gatepost.git
 * [new branch]      master -> master
```

Closes deis/builder#289.
