### PR TITLE
fix(deploy.py): handle chunked output errors

### DIFF
--- a/rootfs/deploy.py
+++ b/rootfs/deploy.py
@@ -13,7 +13,10 @@ def log_output(stream, decode):
     for chunk in stream:
         if 'error' in chunk:
             error = True
-            print(chunk.decode('utf-8'))
+            if isinstance(chunk, basestring):  # Change "basestring" to "str" for Python3
+                print(chunk.decode('utf-8'))
+            else:
+                print(chunk['error'].decode('utf-8'))
         elif decode:
             stream_chunk = chunk.get('stream')
             if stream_chunk:


### PR DESCRIPTION
Handles the runtime case where a chunk of docker-py output is a Python `dict` instead of a `str`. This avoids a stacktrace when trying to print the error output and retains the user-readable error:

``` console
$ git push deis master
Counting objects: 67, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (65/65), done.
Writing objects: 100% (67/67), 11.66 KiB | 0 bytes/s, done.
Total 67 (delta 16), reused 0 (delta 0)
Starting build... but first, coffee!
Step 1 : FROM gliderlabs/alpine:3.4
---> 4ccfa836b1ef
Step 2 : RUN apk-install python
---> Using cache
---> 550faa74361e
Step 3 : ADD . /app
---> Using cache
---> e3c1b72124f5
Step 4 : WORKDIR /app
---> Using cache
---> 81e2a99f6a79
Step 5 : CMD python -m SimpleHTTPServer 5000
---> Using cache
---> f436d99fcba9
Step 6 : FOO
Unknown instruction: FOO
remote: 2016/07/05 22:41:44 Error running git receive hook [Build pod exited with code 1, stopping build.]
To ssh://git@deis-builder.deis.rocks:2222/humble-milepost.git
 ! [remote rejected] master -> master (pre-receive hook declined)
error: failed to push some refs to 'ssh://git@deis-builder.deis.rocks:2222/humble-milepost.git'
```

Closes #73.
