### PR TITLE
fix(deploy.py): delay so stderr is logged before pod exits

### DIFF
--- a/rootfs/deploy.py
+++ b/rootfs/deploy.py
@@ -1,6 +1,7 @@
 import docker
 import os
 import tarfile
+import time
 import requests
 import subprocess
 
@@ -25,6 +26,8 @@ def log_output(stream, decode):
         elif DEBUG:
             print(chunk.decode('utf-8'))
     if error:
+        # HACK: delay so stderr is logged before this dockerbuilder pod exits.
+        time.sleep(3)
         exit(1)
 
 


### PR DESCRIPTION
Output for `git push` of a bad Dockerfile would sometimes fail to show the relevant Docker engine output and instead log the json for a Kubernetes pod error. My assumption was that the `deploy.py` script could exit and terminate the container before the previous print statement had flushed and propagated through to the pod log.

Introducing a small delay before exiting seems to fix the output such that deis/workflow-e2e#249 passes consistently with the stricter `// TODO:` check enabled. I ran `gingko -untilItFails` until neither of us could stand it:

``` console
ginkgo -untilItFails --focus="bad Dockerfile" tests/
...
All tests passed...
Will keep running them until they fail.
This was attempt #41
Maybe you should stop now?
```

Closes #76.
