### PR TITLE
fix(charts): Don't use caps in the configmap keys

### DIFF
--- a/charts/dockerbuilder/templates/dockerbuilder-configmap.yaml
+++ b/charts/dockerbuilder/templates/dockerbuilder-configmap.yaml
@@ -6,4 +6,4 @@ metadata:
     heritage: deis
 data:
   image: "quay.io/{{.Values.org}}/dockerbuilder:{{.Values.docker_tag}}"
-  pullPolicy: {{ .Values.pull_policy }}
+  pullpolicy: {{ .Values.pull_policy }}


### PR DESCRIPTION
this issue is fixed only in 1.4 https://github.com/kubernetes/kubernetes/issues/23722#issuecomment-241164312. Not using caps will allow to support multiple/older k8s versions .