### PR TITLE
chore(.travis.yml): update python to 3.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.7"
+  - "3.5"
 branches:
   only:
     - master


### PR DESCRIPTION
Matches better with `apt-get python3` in the Dockerfile. Apparently we've been running python 3.5.2 in the container but doing unit tests in Travis CI with python 2.7.